### PR TITLE
fixing issue#13, where saved exemplar names were sometimes cut short

### DIFF
--- a/datasets/torchvision_datasets/open_world.py
+++ b/datasets/torchvision_datasets/open_world.py
@@ -292,6 +292,7 @@ class OWDetection(VisionDataset):
         w, h = map(target['annotation']['size'].get, ['width', 'height'])
         target = dict(
             image_id=torch.tensor([self.imgids[index]], dtype=torch.int64),
+            org_image_id=torch.Tensor([ord(c) for c in self.annotations[index].split('/')[-1].split('.xml')[0]]),
             labels=torch.tensor([i['category_id'] for i in instances], dtype=torch.int64),
             area=torch.tensor([i['area'] for i in instances], dtype=torch.float32),
             boxes=torch.as_tensor([i['bbox'] for i in instances], dtype=torch.float32),

--- a/main_open_world.py
+++ b/main_open_world.py
@@ -446,14 +446,8 @@ def create_ft_dataset(args, image_sorted_scores):
         for j in range(len(v['labels'])):
             label = str(v['labels'][j])
             if (v['scores'][j] <= class_threshold[label][0].numpy() or v['scores'][j] >= class_threshold[label][1].numpy()) and (len(imgs_per_class[label])<=args.num_inst_per_class+2):
-                img = str(k)[4:]
-                if len(img)==10:
-                    imgs_per_class[label].append(img[:4]+'_'+img[4:])
-                    save_imgs.append(img[:4]+'_'+img[4:])
-                else:
-                    save_imgs.append(img)
-                    imgs_per_class[label].append(img)
-
+                save_imgs.append(k)
+                imgs_per_class[label].append(k)
                         
     print(f'found {len(np.unique(save_imgs))} images in run')
     if len(args.exemplar_replay_prev_file)>0:


### PR DESCRIPTION
fixing issue#13, where saved exemplar names were sometimes cut short. 
This led to an 'image not found' error in the next exemplar fine-tuning step. 